### PR TITLE
Define base path on Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import vueJsx from '@vitejs/plugin-vue-jsx'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/ynab-on-fire/",
   plugins: [
     vue(),
     vueJsx(),


### PR DESCRIPTION
Should fix 404 when loading resources like js files and favicon in gh-pages.