### PR TITLE
Enable auto merge for all pull requests

### DIFF
--- a/.github/workflows/auto_merge.yaml
+++ b/.github/workflows/auto_merge.yaml
@@ -7,9 +7,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  enable-auto-merge:
     runs-on: ubuntu-latest
-    # yolo
+    # yolo: we don't allow external users to run workflows
     # if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Approve pull request

--- a/.github/workflows/auto_merge.yaml
+++ b/.github/workflows/auto_merge.yaml
@@ -1,0 +1,24 @@
+name: Auto-merge PRs
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # yolo
+    # if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Repository is configured to wait for build to pass before merging.
Only users with write permissions are authorised to run workflows.