### PR TITLE
Mount application after router is ready

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,4 +11,4 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 
-app.mount('#app')
+router.isReady().then(() => app.mount('#app'))


### PR DESCRIPTION
We need to wait for the router to be ready otherwise we are not able to consume query parameters or the hash. The hash is necessary when we receive an OAuth redirect.