### PR TITLE
fix(makefile): auto-install deps before running targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,10 @@
-check:
+node_modules: package.json
+	npm install
+
+check: node_modules
 	npm run format
 	npm run lint
 	npm run type-check
 
-dev:
+dev: node_modules
 	npm run dev -- --open


### PR DESCRIPTION
## Problem
make dev` (and `make check`) failed when `node_modules` was not present because `vite` and other dev dependencies could not be resolved.\n\n## Fix\nAdded a `node_modules: package.json` prerequisite target that runs `npm install` automatically. Both `dev` and `check` targets now declare `node_modules` as a prerequisite.\n\nMake only re-runs `npm install` when `package.json` is newer than `node_modules`, so subsequent invocations are fast and idempotent.