### PR TITLE
feat: FIRE dashboard with retirement cost tracking

### DIFF
--- a/src/components/AccountList.vue
+++ b/src/components/AccountList.vue
@@ -1,17 +1,10 @@
 <script setup lang="ts">
 import { useYnabStore } from '@/stores/ynab'
+import { useFormatCurrency } from '@/composables/useFormatCurrency'
 import { computed } from 'vue'
 
 const ynab = useYnabStore()
-
-const formatCurrency = (amount?: number) => {
-  if (amount === undefined) return '0.00'
-  const isoCode = ynab.selectedBudget?.currency_format?.iso_code || 'GBP'
-  return new Intl.NumberFormat('en-GB', {
-    style: 'currency',
-    currency: isoCode
-  }).format(amount / 1000)
-}
+const { formatCurrency } = useFormatCurrency()
 
 const activeAccounts = computed(() => {
   return ynab.accounts.filter((account) => !account.closed && !account.deleted)
@@ -91,7 +84,7 @@ const isSelected = (accountId: string) => {
                 class="text-lg font-mono font-medium"
                 v-bind:class="[isSelected(account.id) ? 'text-white' : 'text-slate-300']"
               >
-                {{ formatCurrency(account.balance) }}
+                {{ formatCurrency(account.balance / 1000) }}
               </p>
             </div>
           </div>

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -30,7 +30,7 @@ const last12Months = computed(() => {
   const now = new Date()
   const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
   return ynab.months
-    .filter((m) => m.month < currentMonth)
+    .filter((m) => m.month < currentMonth && !m.deleted)
     .sort((a, b) => b.month.localeCompare(a.month))
     .slice(0, 12)
 })

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useYnabStore } from '@/stores/ynab'
+
+const emit = defineEmits<{ 'change-accounts': [] }>()
+
+const ynab = useYnabStore()
+const withdrawalRate = ref(4)
+const rates = [3.5, 4, 4.5, 5]
+
+onMounted(() => {
+  if (ynab.selectedBudget) {
+    ynab.loadMonths(ynab.selectedBudget.id)
+  }
+})
+
+const formatCurrency = (amount: number) => {
+  const isoCode = ynab.selectedBudget?.currency_format?.iso_code ?? 'GBP'
+  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: isoCode }).format(amount)
+}
+
+const portfolioValue = computed(
+  () =>
+    ynab.accounts
+      .filter((a) => ynab.selectedAccountIds.includes(a.id))
+      .reduce((sum, a) => sum + a.balance, 0) / 1000
+)
+
+const last12Months = computed(() => {
+  const now = new Date()
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
+  return ynab.months
+    .filter((m) => m.month < currentMonth)
+    .sort((a, b) => b.month.localeCompare(a.month))
+    .slice(0, 12)
+})
+
+const avgMonthlyIncome = computed(() => {
+  if (last12Months.value.length === 0) return 0
+  return last12Months.value.reduce((sum, m) => sum + m.income, 0) / last12Months.value.length / 1000
+})
+
+const annualIncomeNeeded = computed(() => avgMonthlyIncome.value * 12)
+
+const retirementTarget = computed(() => {
+  if (withdrawalRate.value === 0 || annualIncomeNeeded.value === 0) return 0
+  return annualIncomeNeeded.value / (withdrawalRate.value / 100)
+})
+
+const fireProgress = computed(() => {
+  if (retirementTarget.value === 0) return 0
+  return Math.min(100, (portfolioValue.value / retirementTarget.value) * 100)
+})
+
+const remaining = computed(() => Math.max(0, retirementTarget.value - portfolioValue.value))
+
+const hasReachedFire = computed(
+  () => retirementTarget.value > 0 && portfolioValue.value >= retirementTarget.value
+)
+
+const hasNoData = computed(
+  () => !ynab.loadingMonths && last12Months.value.length === 0 && !ynab.monthsError
+)
+</script>
+
+<template>
+  <div class="py-12 px-4 max-w-4xl mx-auto">
+    <div class="flex items-start justify-between mb-10">
+      <div>
+        <p class="text-slate-400 text-sm font-medium uppercase tracking-widest mb-1">
+          FIRE Dashboard
+        </p>
+        <h2 class="text-3xl font-bold text-white">{{ ynab.selectedBudget?.name }}</h2>
+      </div>
+      <div class="flex gap-4 mt-2">
+        <button
+          @click="emit('change-accounts')"
+          class="text-indigo-400 hover:text-indigo-300 font-medium transition-colors text-sm"
+        >
+          &larr; Change accounts
+        </button>
+        <button
+          @click="ynab.clearSelectedBudget()"
+          class="text-slate-400 hover:text-white font-medium transition-colors text-sm"
+        >
+          Back to budgets
+        </button>
+      </div>
+    </div>
+
+    <div v-if="ynab.loadingMonths" class="flex items-center justify-center py-20">
+      <div
+        class="animate-spin rounded-full h-10 w-10 border-2 border-indigo-500 border-t-transparent"
+      />
+    </div>
+
+    <div
+      v-else-if="ynab.monthsError"
+      class="bg-red-900/30 border border-red-700 rounded-xl p-6 text-red-300"
+    >
+      {{ ynab.monthsError }}
+    </div>
+
+    <div v-else-if="hasNoData" class="text-center py-20 text-slate-400">
+      <p class="text-lg mb-2">No historical data found.</p>
+      <p class="text-sm">Add transactions to your YNAB budget to see your FIRE status.</p>
+    </div>
+
+    <div v-else class="space-y-6">
+      <div>
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          Income Needed in Retirement
+        </h3>
+        <div class="grid grid-cols-2 gap-4">
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Monthly</p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(avgMonthlyIncome) }}</p>
+          </div>
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Annual</p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(annualIncomeNeeded) }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          Your Portfolio ({{ ynab.selectedAccountIds.length }} accounts)
+        </h3>
+        <div class="bg-slate-800 rounded-xl p-6">
+          <p class="text-slate-400 text-sm mb-1">Current Value</p>
+          <p class="text-3xl font-bold text-white">{{ formatCurrency(portfolioValue) }}</p>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          Withdrawal Rate
+        </h3>
+        <div class="flex gap-2">
+          <button
+            v-for="rate in rates"
+            :key="rate"
+            @click="withdrawalRate = rate"
+            :class="[
+              'px-5 py-2 rounded-lg font-semibold text-sm transition-colors',
+              withdrawalRate === rate
+                ? 'bg-indigo-600 text-white'
+                : 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+            ]"
+          >
+            {{ rate }}%
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          Retirement Target &mdash; {{ withdrawalRate }}% rate =
+          {{ (100 / withdrawalRate).toFixed(1) }}&times; annual income
+        </h3>
+        <div class="grid grid-cols-2 gap-4">
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Target</p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(retirementTarget) }}</p>
+          </div>
+          <div class="bg-slate-800 rounded-xl p-6">
+            <template v-if="hasReachedFire">
+              <p class="text-slate-400 text-sm mb-1">Status</p>
+              <p class="text-2xl font-bold text-green-400">You've reached FIRE!</p>
+            </template>
+            <template v-else>
+              <p class="text-slate-400 text-sm mb-1">Remaining</p>
+              <p class="text-2xl font-bold text-white">{{ formatCurrency(remaining) }}</p>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="flex justify-between items-center mb-2">
+          <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider">
+            FIRE Progress
+          </h3>
+          <span class="text-white font-bold text-sm">{{ fireProgress.toFixed(1) }}%</span>
+        </div>
+        <div class="h-4 bg-slate-700 rounded-full overflow-hidden">
+          <div
+            class="h-full bg-linear-to-r from-indigo-500 to-purple-500 rounded-full transition-all duration-500"
+            :style="{ width: `${fireProgress}%` }"
+          />
+        </div>
+        <p v-if="hasReachedFire" class="text-green-400 text-sm mt-3 text-center font-medium">
+          Congratulations — you are financially independent!
+        </p>
+      </div>
+
+      <p class="text-slate-500 text-xs text-center">
+        Based on average monthly income over {{ last12Months.length }} months of YNAB data
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
+import { useFormatCurrency } from '@/composables/useFormatCurrency'
 
 const emit = defineEmits<{ 'change-accounts': [] }>()
 
 const ynab = useYnabStore()
+const { formatCurrency } = useFormatCurrency()
 const withdrawalRate = ref(4)
 const rates = [3.5, 4, 4.5, 5]
 
@@ -13,11 +15,6 @@ onMounted(() => {
     ynab.loadMonths(ynab.selectedBudget.id)
   }
 })
-
-const formatCurrency = (amount: number) => {
-  const isoCode = ynab.selectedBudget?.currency_format?.iso_code ?? 'GBP'
-  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: isoCode }).format(amount)
-}
 
 const portfolioValue = computed(
   () =>

--- a/src/components/__tests__/RetirementDashboard.spec.ts
+++ b/src/components/__tests__/RetirementDashboard.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { useYnabStore } from '@/stores/ynab'
+import RetirementDashboard from '../RetirementDashboard.vue'
+
+describe('RetirementDashboard', () => {
+  let ynab: ReturnType<typeof useYnabStore>
+
+  const makeMonth = (monthsAgo: number, income: number, deleted = false) => {
+    const d = new Date()
+    d.setDate(1)
+    d.setMonth(d.getMonth() - monthsAgo)
+    return {
+      month: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`,
+      income,
+      budgeted: income,
+      activity: -income,
+      to_be_budgeted: 0,
+      deleted,
+    }
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    ynab = useYnabStore()
+    ynab.selectedBudget = {
+      id: 'b1',
+      name: 'Test Budget',
+      currency_format: { iso_code: 'GBP' },
+    } as any
+    ynab.accounts = [
+      { id: 'acc1', balance: 10_000_000, closed: false, deleted: false } as any,
+      { id: 'acc2', balance: 20_000_000, closed: false, deleted: false } as any,
+    ]
+    ynab.selectedAccountIds = ['acc1', 'acc2']
+    // 12 months at £2,000/month income (2,000,000 milliunits each)
+    ynab.months = Array.from({ length: 12 }, (_, i) => makeMonth(i + 1, 2_000_000)) as any
+  })
+
+  it('shows spinner while loading months', () => {
+    ynab.loadingMonths = true
+    const wrapper = mount(RetirementDashboard)
+    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+  })
+
+  it('shows error message on load failure', () => {
+    ynab.monthsError = 'Failed to load monthly data'
+    const wrapper = mount(RetirementDashboard)
+    expect(wrapper.text()).toContain('Failed to load monthly data')
+  })
+
+  it('shows no-data message when months list is empty', () => {
+    ynab.months = []
+    const wrapper = mount(RetirementDashboard)
+    expect(wrapper.text()).toContain('No historical data found')
+  })
+
+  it('renders correct portfolio value from selected accounts', () => {
+    const wrapper = mount(RetirementDashboard)
+    // (10,000,000 + 20,000,000) / 1000 = £30,000
+    expect(wrapper.text()).toContain('30,000')
+  })
+
+  it('renders correct monthly income needed', () => {
+    const wrapper = mount(RetirementDashboard)
+    // avg 2,000,000 milliunits / 1000 = £2,000
+    expect(wrapper.text()).toContain('£2,000')
+  })
+
+  it('renders correct retirement target at 4% withdrawal rate', () => {
+    const wrapper = mount(RetirementDashboard)
+    // annual = £2,000 × 12 = £24,000; target = £24,000 / 0.04 = £600,000
+    expect(wrapper.text()).toContain('600,000')
+  })
+
+  it('renders correct remaining to FIRE', () => {
+    const wrapper = mount(RetirementDashboard)
+    // £600,000 - £30,000 = £570,000
+    expect(wrapper.text()).toContain('570,000')
+  })
+
+  it('renders correct FIRE progress percentage', () => {
+    const wrapper = mount(RetirementDashboard)
+    // £30,000 / £600,000 = 5.0%
+    expect(wrapper.text()).toContain('5.0%')
+  })
+
+  it('excludes deleted months from income average', () => {
+    ynab.months = [
+      makeMonth(1, 3_000_000), // £3,000 — valid
+      makeMonth(2, 9_000_000, true), // deleted — must not affect average
+    ] as any
+    const wrapper = mount(RetirementDashboard)
+    // avg = £3,000 monthly → annual £36,000 (not £72,000 if deleted were included)
+    expect(wrapper.text()).toContain('36,000')
+    expect(wrapper.text()).not.toContain('72,000')
+  })
+
+  it('updates retirement target when withdrawal rate changes', async () => {
+    const wrapper = mount(RetirementDashboard)
+    // Default 4%: annual £24,000 → target £600,000
+    expect(wrapper.text()).toContain('600,000')
+
+    // Switch to 5%: target = £24,000 / 0.05 = £480,000
+    const fiveBtn = wrapper.findAll('button').find((b) => b.text().trim() === '5%')
+    await fiveBtn!.trigger('click')
+    expect(wrapper.text()).toContain('480,000')
+  })
+
+  it('emits change-accounts when navigation button clicked', async () => {
+    const wrapper = mount(RetirementDashboard)
+    const changeBtn = wrapper.findAll('button').find((b) => b.text().includes('Change accounts'))
+    await changeBtn!.trigger('click')
+    expect(wrapper.emitted('change-accounts')).toBeTruthy()
+  })
+})

--- a/src/components/__tests__/RetirementDashboard.spec.ts
+++ b/src/components/__tests__/RetirementDashboard.spec.ts
@@ -17,7 +17,7 @@ describe('RetirementDashboard', () => {
       budgeted: income,
       activity: -income,
       to_be_budgeted: 0,
-      deleted,
+      deleted
     }
   }
 
@@ -27,11 +27,11 @@ describe('RetirementDashboard', () => {
     ynab.selectedBudget = {
       id: 'b1',
       name: 'Test Budget',
-      currency_format: { iso_code: 'GBP' },
+      currency_format: { iso_code: 'GBP' }
     } as any
     ynab.accounts = [
       { id: 'acc1', balance: 10_000_000, closed: false, deleted: false } as any,
-      { id: 'acc2', balance: 20_000_000, closed: false, deleted: false } as any,
+      { id: 'acc2', balance: 20_000_000, closed: false, deleted: false } as any
     ]
     ynab.selectedAccountIds = ['acc1', 'acc2']
     // 12 months at £2,000/month income (2,000,000 milliunits each)
@@ -89,7 +89,7 @@ describe('RetirementDashboard', () => {
   it('excludes deleted months from income average', () => {
     ynab.months = [
       makeMonth(1, 3_000_000), // £3,000 — valid
-      makeMonth(2, 9_000_000, true), // deleted — must not affect average
+      makeMonth(2, 9_000_000, true) // deleted — must not affect average
     ] as any
     const wrapper = mount(RetirementDashboard)
     // avg = £3,000 monthly → annual £36,000 (not £72,000 if deleted were included)

--- a/src/composables/useFormatCurrency.ts
+++ b/src/composables/useFormatCurrency.ts
@@ -1,0 +1,12 @@
+import { useYnabStore } from '@/stores/ynab'
+
+export function useFormatCurrency() {
+  const ynab = useYnabStore()
+
+  const formatCurrency = (amount: number) => {
+    const isoCode = ynab.selectedBudget?.currency_format?.iso_code ?? 'GBP'
+    return new Intl.NumberFormat('en-GB', { style: 'currency', currency: isoCode }).format(amount)
+  }
+
+  return { formatCurrency }
+}

--- a/src/stores/__tests__/ynab.spec.ts
+++ b/src/stores/__tests__/ynab.spec.ts
@@ -52,6 +52,8 @@ describe('ynab store', () => {
       name: 'Budget Name'
     }
     ynab.budgets = [ynab.selectedBudget]
+    ynab.months = [{ month: '2026-01-01' } as any]
+    ynab.monthsError = 'some error'
 
     // the token is written async
     await flushPromises()
@@ -64,6 +66,8 @@ describe('ynab store', () => {
     expect(ynab.isAuthorised).toBe(false)
     expect(ynab.budgets).toStrictEqual([])
     expect(ynab.selectedBudget).toBeUndefined()
+    expect(ynab.months).toStrictEqual([])
+    expect(ynab.monthsError).toBeNull()
     expect(sessionStorage.getItem(YNAB_ACCESS_TOKEN)).toBe(null)
   })
 
@@ -71,11 +75,25 @@ describe('ynab store', () => {
     const ynab = useYnabStore()
     const budget = { id: 'b1', name: 'Budget 1' }
     ynab.selectBudget(budget as any)
+    ynab.months = [{ month: '2026-01-01' } as any]
+    ynab.monthsError = 'some error'
     expect(ynab.selectedBudget).toEqual(budget)
 
     ynab.clearSelectedBudget()
     expect(ynab.selectedBudget).toBeUndefined()
     expect(ynab.accounts).toEqual([])
     expect(ynab.selectedAccountIds).toEqual([])
+    expect(ynab.months).toEqual([])
+    expect(ynab.monthsError).toBeNull()
+  })
+
+  it('loadMonths does nothing when api is not initialised', async () => {
+    const ynab = useYnabStore()
+    ynab.months = [{ month: '2026-01-01' } as any]
+    await ynab.loadMonths('budget_id')
+    // api is null, so months and loading state must be unchanged
+    expect(ynab.months).toHaveLength(1)
+    expect(ynab.loadingMonths).toBe(false)
+    expect(ynab.monthsError).toBeNull()
   })
 })

--- a/src/stores/ynab.ts
+++ b/src/stores/ynab.ts
@@ -30,6 +30,10 @@ export const useYnabStore = defineStore('ynab', () => {
 
   const selectedBudget = ref<ynab.BudgetSummary>()
 
+  const months = ref<ynab.MonthSummary[]>([])
+  const loadingMonths = ref(false)
+  const monthsError = ref<string | null>(null)
+
   const authUri = computed(
     () =>
       `https://app.ynab.com/oauth/authorize?client_id=${apiConfig.value.clientId}&redirect_uri=${apiConfig.value.redirectUri}&response_type=token`
@@ -48,12 +52,16 @@ export const useYnabStore = defineStore('ynab', () => {
     selectedBudget.value = undefined
     accounts.value = []
     selectedAccountIds.value = []
+    months.value = []
+    monthsError.value = null
   }
 
   function clearSelectedBudget() {
     selectedBudget.value = undefined
     accounts.value = []
     selectedAccountIds.value = []
+    months.value = []
+    monthsError.value = null
   }
 
   function selectBudget(budget: ynab.BudgetSummary) {
@@ -95,6 +103,20 @@ export const useYnabStore = defineStore('ynab', () => {
     }
   }
 
+  async function loadMonths(budgetId: string) {
+    if (api.value == null) return
+    loadingMonths.value = true
+    monthsError.value = null
+    try {
+      const response = await api.value.months.getBudgetMonths(budgetId)
+      months.value = response.data.months
+    } catch {
+      monthsError.value = 'Failed to load monthly data'
+    } finally {
+      loadingMonths.value = false
+    }
+  }
+
   if (isAuthorised.value) {
     api.value = new ynab.api(accessToken.value)
     loadBudgets()
@@ -115,6 +137,10 @@ export const useYnabStore = defineStore('ynab', () => {
     selectedAccountIds,
     loadingAccounts,
     accountsError,
-    loadAccounts
+    loadAccounts,
+    months,
+    loadingMonths,
+    monthsError,
+    loadMonths
   }
 })

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
 import BudgetList from '@/components/BudgetList.vue'
 import AccountList from '@/components/AccountList.vue'
+import RetirementDashboard from '@/components/RetirementDashboard.vue'
 import LockIcon from '@/components/icons/LockIcon.vue'
 
 const ynab = useYnabStore()
@@ -39,30 +40,10 @@ watch(
       Authorise with YNAB
     </a>
   </div>
-  <div v-else-if="ynab.selectedBudget && isConfirmed" class="py-12 px-4 max-w-4xl mx-auto">
-    <!-- Selected Budget View Placeholder -->
-    <h2 class="text-3xl font-bold text-white mb-4">
-      {{ ynab.selectedBudget.name }}
-    </h2>
-    <p class="text-slate-400">
-      Portfolio analysis dashboard for
-      {{ ynab.selectedAccountIds.length }} accounts coming soon...
-    </p>
-    <div class="mt-8 flex space-x-4">
-      <button
-        v-on:click="isConfirmed = false"
-        class="text-indigo-400 hover:text-indigo-300 font-medium transition-colors"
-      >
-        &larr; Change accounts
-      </button>
-      <button
-        v-on:click="ynab.clearSelectedBudget()"
-        class="text-slate-400 hover:text-white font-medium transition-colors"
-      >
-        Back to budgets
-      </button>
-    </div>
-  </div>
+  <RetirementDashboard
+    v-else-if="ynab.selectedBudget && isConfirmed"
+    @change-accounts="isConfirmed = false"
+  />
   <AccountList v-else-if="ynab.selectedBudget" v-on:confirm="isConfirmed = true" />
   <BudgetList v-else />
 </template>


### PR DESCRIPTION
## Summary

- Replaces the portfolio analysis placeholder with a full FIRE (Financial Independence, Retire Early) dashboard
- Loads last 12 months of YNAB history to calculate average monthly income needed in retirement
- Shows current portfolio value (selected accounts), configurable retirement target (3.5–5% withdrawal rate), remaining gap, and FIRE progress bar
- Extracts shared `useFormatCurrency` composable to remove duplication between components

## Changes

- `src/components/RetirementDashboard.vue` — new FIRE dashboard component
- `src/stores/ynab.ts` — adds `months` state and `loadMonths()` via `getBudgetMonths` API; clears months on logout/budget change
- `src/views/HomeView.vue` — replaces placeholder with `<RetirementDashboard>`
- `src/composables/useFormatCurrency.ts` — shared currency formatting composable
- `src/components/__tests__/RetirementDashboard.spec.ts` — 11 new component tests covering all FIRE metrics, states, and edge cases
- `src/stores/__tests__/ynab.spec.ts` — extended to cover months cleanup and `loadMonths` null-api guard

## Test plan

- [ ] Authorise with YNAB → select a budget → select accounts → confirm
- [ ] Dashboard loads and displays monthly/annual income, portfolio value, retirement target, remaining, and progress bar
- [ ] Click withdrawal rate pills (3.5% / 4% / 4.5% / 5%) — target and remaining update reactively
- [ ] "← Change accounts" returns to account selection; "Back to budgets" resets to budget list
- [ ] `make check` passes (format + lint + type-check)
- [ ] `npm run test:unit` — 23/23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)