### PR TITLE
feat: add category selection step to estimate monthly retirement budget

### DIFF
--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useYnabStore } from '@/stores/ynab'
+import { useFormatCurrency } from '@/composables/useFormatCurrency'
+
+const emit = defineEmits<{ confirm: []; back: [] }>()
+
+const ynab = useYnabStore()
+const { formatCurrency } = useFormatCurrency()
+
+onMounted(() => {
+  if (ynab.selectedBudget) {
+    ynab.loadCategories(ynab.selectedBudget.id)
+  }
+})
+
+const activeGroups = computed(() =>
+  ynab.categoryGroups
+    .filter((g) => !g.deleted && g.name !== 'Internal Master Category')
+    .map((g) => ({
+      ...g,
+      categories: g.categories.filter((c) => !c.hidden && !c.deleted)
+    }))
+    .filter((g) => g.categories.length > 0)
+)
+
+const toggleCategory = (categoryId: string) => {
+  const index = ynab.selectedCategoryIds.indexOf(categoryId)
+  if (index === -1) {
+    ynab.selectedCategoryIds.push(categoryId)
+  } else {
+    ynab.selectedCategoryIds.splice(index, 1)
+  }
+}
+
+const isSelected = (categoryId: string) => ynab.selectedCategoryIds.includes(categoryId)
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center py-12 px-4">
+    <div class="text-center mb-12">
+      <h1 class="text-4xl md:text-5xl font-bold text-white mb-4 tracking-tight">
+        Select retirement categories
+      </h1>
+      <p class="text-slate-400 text-lg md:text-xl max-w-2xl mx-auto">
+        Choose which spending categories you expect to have in retirement
+      </p>
+    </div>
+
+    <div v-if="ynab.loadingCategories" class="flex flex-col items-center justify-center py-20">
+      <div
+        class="w-12 h-12 border-4 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin mb-4"
+      ></div>
+      <p class="text-slate-400">Loading categories...</p>
+    </div>
+
+    <div v-else-if="ynab.categoriesError" class="text-center py-20">
+      <p class="text-red-400 text-lg mb-4">{{ ynab.categoriesError }}</p>
+      <button
+        @click="ynab.loadCategories(ynab.selectedBudget!.id)"
+        class="text-indigo-400 hover:text-indigo-300 font-medium"
+      >
+        Try again
+      </button>
+    </div>
+
+    <template v-else>
+      <div class="w-full max-w-4xl mb-12 space-y-8">
+        <div v-for="group in activeGroups" :key="group.id">
+          <p class="text-slate-500 text-xs font-semibold uppercase tracking-wider mb-3">
+            {{ group.name }}
+          </p>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div
+              v-for="category in group.categories"
+              :key="category.id"
+              @click="toggleCategory(category.id)"
+              class="group relative overflow-hidden bg-slate-900/50 border rounded-2xl p-5 cursor-pointer transition-all duration-300 backdrop-blur-xl active:scale-[0.98]"
+              :class="[
+                isSelected(category.id)
+                  ? 'border-indigo-500 bg-indigo-500/10'
+                  : 'border-slate-800 hover:border-slate-700 hover:bg-slate-800/80'
+              ]"
+            >
+              <div class="flex items-center justify-between">
+                <h3
+                  class="text-base font-semibold transition-colors duration-300 pr-6"
+                  :class="[isSelected(category.id) ? 'text-indigo-300' : 'text-white']"
+                >
+                  {{ category.name }}
+                </h3>
+                <p
+                  class="text-base font-mono font-medium shrink-0"
+                  :class="[isSelected(category.id) ? 'text-white' : 'text-slate-300']"
+                >
+                  {{ category.budgeted !== 0 ? formatCurrency(category.budgeted / 1000) : '—' }}
+                </p>
+              </div>
+
+              <div
+                class="absolute top-3 right-3 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all duration-300"
+                :class="[
+                  isSelected(category.id)
+                    ? 'bg-indigo-500 border-indigo-500'
+                    : 'border-slate-700 opacity-0 group-hover:opacity-100'
+                ]"
+              >
+                <svg
+                  v-if="isSelected(category.id)"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-3.5 w-3.5 text-white"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sticky bottom-8 w-full max-w-4xl flex justify-center">
+        <button
+          @click="emit('back')"
+          class="mr-4 px-8 py-3 rounded-xl bg-slate-800 hover:bg-slate-700 text-white font-semibold transition-all"
+        >
+          &larr; Back
+        </button>
+        <button
+          :disabled="ynab.selectedCategoryIds.length === 0"
+          @click="emit('confirm')"
+          class="px-12 py-3 rounded-xl font-bold text-lg transition-all shadow-2xl shadow-indigo-500/25 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
+          :class="[
+            ynab.selectedCategoryIds.length > 0
+              ? 'bg-linear-to-r from-indigo-600 to-purple-600 hover:from-indigo-500 hover:to-purple-500 text-white'
+              : 'bg-slate-800 text-slate-500'
+          ]"
+        >
+          Analyse {{ ynab.selectedCategoryIds.length }} Categor{{
+            ynab.selectedCategoryIds.length === 1 ? 'y' : 'ies'
+          }}
+        </button>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
 import { useFormatCurrency } from '@/composables/useFormatCurrency'
 
-const emit = defineEmits<{ 'change-accounts': [] }>()
+const emit = defineEmits<{ 'change-accounts': []; 'change-categories': [] }>()
 
 const ynab = useYnabStore()
 const { formatCurrency } = useFormatCurrency()
@@ -37,7 +37,16 @@ const avgMonthlyIncome = computed(() => {
   return last12Months.value.reduce((sum, m) => sum + m.income, 0) / last12Months.value.length / 1000
 })
 
-const annualIncomeNeeded = computed(() => avgMonthlyIncome.value * 12)
+const selectedCategoriesMonthly = computed(() => {
+  if (ynab.selectedCategoryIds.length === 0) return null
+  const allCategories = ynab.categoryGroups.flatMap((g) => g.categories)
+  const selected = allCategories.filter((c) => ynab.selectedCategoryIds.includes(c.id))
+  return selected.reduce((sum, c) => sum + c.budgeted, 0) / 1000
+})
+
+const monthlyNeeded = computed(() => selectedCategoriesMonthly.value ?? avgMonthlyIncome.value)
+
+const annualIncomeNeeded = computed(() => monthlyNeeded.value * 12)
 
 const retirementTarget = computed(() => {
   if (withdrawalRate.value === 0 || annualIncomeNeeded.value === 0) return 0
@@ -70,6 +79,12 @@ const hasNoData = computed(
         <h2 class="text-3xl font-bold text-white">{{ ynab.selectedBudget?.name }}</h2>
       </div>
       <div class="flex gap-4 mt-2">
+        <button
+          @click="emit('change-categories')"
+          class="text-indigo-400 hover:text-indigo-300 font-medium transition-colors text-sm"
+        >
+          &larr; Change categories
+        </button>
         <button
           @click="emit('change-accounts')"
           class="text-indigo-400 hover:text-indigo-300 font-medium transition-colors text-sm"
@@ -106,12 +121,16 @@ const hasNoData = computed(
     <div v-else class="space-y-6">
       <div>
         <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
-          Income Needed in Retirement
+          {{
+            selectedCategoriesMonthly !== null
+              ? 'Monthly Retirement Budget'
+              : 'Income Needed in Retirement'
+          }}
         </h3>
         <div class="grid grid-cols-2 gap-4">
           <div class="bg-slate-800 rounded-xl p-6">
             <p class="text-slate-400 text-sm mb-1">Monthly</p>
-            <p class="text-2xl font-bold text-white">{{ formatCurrency(avgMonthlyIncome) }}</p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(monthlyNeeded) }}</p>
           </div>
           <div class="bg-slate-800 rounded-xl p-6">
             <p class="text-slate-400 text-sm mb-1">Annual</p>
@@ -193,7 +212,13 @@ const hasNoData = computed(
       </div>
 
       <p class="text-slate-500 text-xs text-center">
-        Based on average monthly income over {{ last12Months.length }} months of YNAB data
+        <template v-if="selectedCategoriesMonthly !== null">
+          Based on {{ ynab.selectedCategoryIds.length }} selected
+          {{ ynab.selectedCategoryIds.length === 1 ? 'category' : 'categories' }}
+        </template>
+        <template v-else>
+          Based on average monthly income over {{ last12Months.length }} months of YNAB data
+        </template>
       </p>
     </div>
   </div>

--- a/src/stores/ynab.ts
+++ b/src/stores/ynab.ts
@@ -34,6 +34,11 @@ export const useYnabStore = defineStore('ynab', () => {
   const loadingMonths = ref(false)
   const monthsError = ref<string | null>(null)
 
+  const categoryGroups = ref<ynab.CategoryGroupWithCategories[]>([])
+  const selectedCategoryIds = ref<string[]>([])
+  const loadingCategories = ref(false)
+  const categoriesError = ref<string | null>(null)
+
   const authUri = computed(
     () =>
       `https://app.ynab.com/oauth/authorize?client_id=${apiConfig.value.clientId}&redirect_uri=${apiConfig.value.redirectUri}&response_type=token`
@@ -54,6 +59,9 @@ export const useYnabStore = defineStore('ynab', () => {
     selectedAccountIds.value = []
     months.value = []
     monthsError.value = null
+    categoryGroups.value = []
+    selectedCategoryIds.value = []
+    categoriesError.value = null
   }
 
   function clearSelectedBudget() {
@@ -62,6 +70,9 @@ export const useYnabStore = defineStore('ynab', () => {
     selectedAccountIds.value = []
     months.value = []
     monthsError.value = null
+    categoryGroups.value = []
+    selectedCategoryIds.value = []
+    categoriesError.value = null
   }
 
   function selectBudget(budget: ynab.BudgetSummary) {
@@ -103,6 +114,20 @@ export const useYnabStore = defineStore('ynab', () => {
     }
   }
 
+  async function loadCategories(budgetId: string) {
+    if (api.value == null) return
+    loadingCategories.value = true
+    categoriesError.value = null
+    try {
+      const res = await api.value.categories.getCategories(budgetId)
+      categoryGroups.value = res.data.category_groups
+    } catch {
+      categoriesError.value = 'Failed to load categories'
+    } finally {
+      loadingCategories.value = false
+    }
+  }
+
   async function loadMonths(budgetId: string) {
     if (api.value == null) return
     loadingMonths.value = true
@@ -141,6 +166,11 @@ export const useYnabStore = defineStore('ynab', () => {
     months,
     loadingMonths,
     monthsError,
-    loadMonths
+    loadMonths,
+    categoryGroups,
+    selectedCategoryIds,
+    loadingCategories,
+    categoriesError,
+    loadCategories
   }
 })

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,17 +3,19 @@ import { ref, watch } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
 import BudgetList from '@/components/BudgetList.vue'
 import AccountList from '@/components/AccountList.vue'
+import CategoryList from '@/components/CategoryList.vue'
 import RetirementDashboard from '@/components/RetirementDashboard.vue'
 import LockIcon from '@/components/icons/LockIcon.vue'
 
 const ynab = useYnabStore()
-const isConfirmed = ref(false)
+const isAccountsConfirmed = ref(false)
+const isCategoriesConfirmed = ref(false)
 
-// Reset confirmation when budget changes or is cleared
 watch(
   () => ynab.selectedBudget,
   () => {
-    isConfirmed.value = false
+    isAccountsConfirmed.value = false
+    isCategoriesConfirmed.value = false
   }
 )
 </script>
@@ -41,9 +43,18 @@ watch(
     </a>
   </div>
   <RetirementDashboard
-    v-else-if="ynab.selectedBudget && isConfirmed"
-    @change-accounts="isConfirmed = false"
+    v-else-if="ynab.selectedBudget && isAccountsConfirmed && isCategoriesConfirmed"
+    @change-categories="isCategoriesConfirmed = false"
+    @change-accounts="
+      isAccountsConfirmed = false
+      isCategoriesConfirmed = false
+    "
   />
-  <AccountList v-else-if="ynab.selectedBudget" v-on:confirm="isConfirmed = true" />
+  <CategoryList
+    v-else-if="ynab.selectedBudget && isAccountsConfirmed"
+    @confirm="isCategoriesConfirmed = true"
+    @back="isAccountsConfirmed = false"
+  />
+  <AccountList v-else-if="ynab.selectedBudget" @confirm="isAccountsConfirmed = true" />
   <BudgetList v-else />
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -18,6 +18,11 @@ watch(
     isCategoriesConfirmed.value = false
   }
 )
+
+function resetToAccounts() {
+  isAccountsConfirmed.value = false
+  isCategoriesConfirmed.value = false
+}
 </script>
 
 <template>
@@ -45,10 +50,7 @@ watch(
   <RetirementDashboard
     v-else-if="ynab.selectedBudget && isAccountsConfirmed && isCategoriesConfirmed"
     @change-categories="isCategoriesConfirmed = false"
-    @change-accounts="
-      isAccountsConfirmed = false
-      isCategoriesConfirmed = false
-    "
+    @change-accounts="resetToAccounts"
   />
   <CategoryList
     v-else-if="ynab.selectedBudget && isAccountsConfirmed"


### PR DESCRIPTION
## Summary

- Adds a new **CategoryList** wizard step between account selection and the FIRE dashboard — the flow is now: Budgets → Accounts → Categories → Dashboard
- Users multi-select YNAB expense categories that represent their expected retirement spending; the sum of their current `budgeted` amounts replaces the income-based estimate on the dashboard
- Dashboard gains a "← Change categories" back button; section header and footer note update dynamically based on whether categories or income is being used

## Test plan

- [ ] Walk the full wizard: Budgets → Accounts → Categories → Dashboard
- [ ] Confirm categories load grouped by YNAB group, with hidden/deleted/system ("Internal Master Category") entries filtered out
- [ ] Select categories and verify "Monthly Retirement Budget" and FIRE target update to reflect their sum
- [ ] Click "← Change categories" → returns to CategoryList with selection preserved
- [ ] Click "← Change accounts" → returns to AccountList with both flags reset
- [ ] Click "Back to budgets" → full state reset
- [ ] Verify footer note reads "Based on X selected categories" when categories are active
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)