### PR TITLE
feat: use environment-specific redirect URI and show DEV badge

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_REDIRECT_URI=http://localhost:5173/ynab-on-fire/

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_REDIRECT_URI=https://rpussente.github.io/ynab-on-fire/

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,8 @@ const route = useRoute()
 const router = useRouter()
 const ynab = useYnabStore()
 
+const isDev = import.meta.env.DEV
+
 const ynabToken = findYnabToken()
 
 if (ynabToken != null) {
@@ -37,6 +39,12 @@ function findYnabToken() {
         >
           YNAB on Fire
         </RouterLink>
+        <span
+          v-if="isDev"
+          class="px-2 py-0.5 rounded text-xs font-semibold bg-amber-500/20 text-amber-400 border border-amber-500/30 tracking-wide"
+        >
+          DEV
+        </span>
       </div>
 
       <div class="flex items-center space-x-6">

--- a/src/stores/ynab.ts
+++ b/src/stores/ynab.ts
@@ -17,7 +17,7 @@ export const useYnabStore = defineStore('ynab', () => {
   const api = ref<ynab.api | null>(null)
   const apiConfig = ref<Ynab>({
     clientId: jsonConfig.clientId,
-    redirectUri: jsonConfig.redirectUri
+    redirectUri: import.meta.env.VITE_REDIRECT_URI ?? jsonConfig.redirectUri
   })
   const accessToken = useSessionStorage<string>(YNAB_ACCESS_TOKEN, null)
 


### PR DESCRIPTION
## Summary

- Adds `.env.development` and `.env.production` files to set `VITE_REDIRECT_URI` per environment, so the dev server uses `http://localhost:5173/ynab-on-fire/` and production keeps the GitHub Pages URI
- Reads `VITE_REDIRECT_URI` in the YNAB store with a fallback to `ynab.config.json`, making local OAuth flow work without modifying the config file
- Shows a `DEV` badge in the header when running in development mode (`import.meta.env.DEV`)

## Test plan

- [ ] Run `npm run dev` and verify the `DEV` badge appears in the header
- [ ] Click "Authorise with YNAB" and confirm the redirect URI is `http://localhost:5173/ynab-on-fire/`
- [ ] Confirm production build uses the GitHub Pages redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)