### PR TITLE
feat: FIRE progress projection chart and estimated FIRE date

### DIFF
--- a/src/components/FireProgressChart.vue
+++ b/src/components/FireProgressChart.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  points: Array<{ monthIndex: number; progress: number }>
+  totalMonths: number
+  fireMonthIndex: number | null
+  currentProgress: number
+}>()
+
+const LEFT = 48
+const RIGHT = 776
+const TOP = 16
+const BOTTOM = 264
+const PLOT_W = RIGHT - LEFT // 728
+const PLOT_H = BOTTOM - TOP // 248
+
+function xFor(monthIndex: number): number {
+  return LEFT + (monthIndex / props.totalMonths) * PLOT_W
+}
+
+function yFor(progress: number): number {
+  return BOTTOM - (progress / 100) * PLOT_H
+}
+
+const yearStepMonths = computed(() => {
+  const years = props.totalMonths / 12
+  if (years <= 10) return 12
+  if (years <= 20) return 24
+  return 60
+})
+
+const baseYear = new Date().getFullYear()
+
+const xAxisLabels = computed(() => {
+  const labels: { x: number; label: string }[] = []
+  for (let m = 0; m <= props.totalMonths; m += yearStepMonths.value) {
+    labels.push({ x: xFor(m), label: String(baseYear + Math.round(m / 12)) })
+  }
+  return labels
+})
+
+const gridLines = [0, 25, 50, 75, 100]
+
+const linePoints = computed(() =>
+  props.points.map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`).join(' ')
+)
+
+const areaPoints = computed(() => {
+  if (props.points.length === 0) return ''
+  const last = props.points[props.points.length - 1]
+  const pathPoints = [
+    `${xFor(0)},${BOTTOM}`,
+    ...props.points.map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`),
+    `${xFor(last.monthIndex)},${BOTTOM}`
+  ]
+  return pathPoints.join(' ')
+})
+</script>
+
+<template>
+  <svg
+    viewBox="0 0 800 300"
+    class="w-full h-auto"
+    role="img"
+    aria-label="FIRE projection chart"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <linearGradient id="fire-fill" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#6366f1" stop-opacity="0.4" />
+        <stop offset="100%" stop-color="#a855f7" stop-opacity="0.05" />
+      </linearGradient>
+      <linearGradient id="fire-line" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#6366f1" />
+        <stop offset="100%" stop-color="#a855f7" />
+      </linearGradient>
+    </defs>
+
+    <!-- Y-axis gridlines -->
+    <g v-for="pct in gridLines" :key="pct">
+      <line
+        :x1="LEFT"
+        :x2="RIGHT"
+        :y1="yFor(pct)"
+        :y2="yFor(pct)"
+        stroke="#334155"
+        stroke-width="1"
+        stroke-dasharray="4 4"
+      />
+      <text :x="LEFT - 6" :y="yFor(pct) + 4" fill="#64748b" font-size="10" text-anchor="end">
+        {{ pct }}%
+      </text>
+    </g>
+
+    <!-- 100% FIRE target line (more prominent) -->
+    <line
+      :x1="LEFT"
+      :x2="RIGHT"
+      :y1="yFor(100)"
+      :y2="yFor(100)"
+      stroke="#6366f1"
+      stroke-width="1.5"
+      stroke-dasharray="6 4"
+      opacity="0.7"
+    />
+    <text :x="RIGHT + 4" :y="yFor(100) + 4" fill="#6366f1" font-size="10">FIRE</text>
+
+    <!-- Filled area under the line -->
+    <polygon v-if="points.length > 0" :points="areaPoints" fill="url(#fire-fill)" />
+
+    <!-- Projection line -->
+    <polyline
+      v-if="points.length > 0"
+      :points="linePoints"
+      fill="none"
+      stroke="url(#fire-line)"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <!-- Estimated FIRE date vertical marker -->
+    <g v-if="fireMonthIndex !== null && fireMonthIndex <= totalMonths">
+      <line
+        :x1="xFor(fireMonthIndex)"
+        :x2="xFor(fireMonthIndex)"
+        :y1="TOP"
+        :y2="BOTTOM"
+        stroke="#a855f7"
+        stroke-width="1.5"
+        stroke-dasharray="4 4"
+      />
+      <circle
+        :cx="xFor(fireMonthIndex)"
+        :cy="yFor(100)"
+        r="5"
+        fill="#a855f7"
+        stroke="#1e293b"
+        stroke-width="2"
+      />
+    </g>
+
+    <!-- Today's dot -->
+    <circle
+      :cx="xFor(0)"
+      :cy="yFor(currentProgress)"
+      r="4"
+      fill="#6366f1"
+      stroke="#1e293b"
+      stroke-width="2"
+    />
+
+    <!-- X-axis year labels -->
+    <text
+      v-for="label in xAxisLabels"
+      :key="label.label"
+      :x="label.x"
+      y="288"
+      fill="#64748b"
+      font-size="10"
+      text-anchor="middle"
+    >
+      {{ label.label }}
+    </text>
+  </svg>
+</template>

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -71,6 +71,9 @@ const hasNoData = computed(
 
 const avgMonthlySavings = computed(() => {
   if (last12Months.value.length === 0) return 0
+  if (selectedCategoriesMonthly.value !== null) {
+    return avgMonthlyIncome.value - selectedCategoriesMonthly.value
+  }
   return (
     last12Months.value.reduce((sum, m) => sum + m.income + m.activity, 0) /
     last12Months.value.length /

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
 import { useFormatCurrency } from '@/composables/useFormatCurrency'
+import FireProgressChart from '@/components/FireProgressChart.vue'
 
 const emit = defineEmits<{ 'change-accounts': []; 'change-categories': [] }>()
 
@@ -67,6 +68,57 @@ const hasReachedFire = computed(
 const hasNoData = computed(
   () => !ynab.loadingMonths && last12Months.value.length === 0 && !ynab.monthsError
 )
+
+const avgMonthlySavings = computed(() => {
+  if (last12Months.value.length === 0) return 0
+  return (
+    last12Months.value.reduce((sum, m) => sum + m.income + m.activity, 0) /
+    last12Months.value.length /
+    1000
+  )
+})
+
+const monthsToFire = computed(() => {
+  if (avgMonthlySavings.value <= 0 || hasReachedFire.value) return null
+  return remaining.value / avgMonthlySavings.value
+})
+
+const yearsToFire = computed(() => (monthsToFire.value === null ? null : monthsToFire.value / 12))
+
+const estimatedFireDate = computed(() => {
+  if (monthsToFire.value === null) return null
+  const d = new Date()
+  d.setDate(1)
+  d.setMonth(d.getMonth() + Math.ceil(monthsToFire.value))
+  return d
+})
+
+const formattedFireDate = computed(() => {
+  if (!estimatedFireDate.value) return '—'
+  return estimatedFireDate.value.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+})
+
+const yearsAwayLabel = computed(() => {
+  if (yearsToFire.value === null) return ''
+  const y = Math.ceil(yearsToFire.value)
+  return `~${y} ${y === 1 ? 'year' : 'years'} away`
+})
+
+const chartYears = computed(() =>
+  yearsToFire.value === null ? 40 : Math.min(yearsToFire.value + 2, 40)
+)
+
+const projectionPoints = computed(() => {
+  if (retirementTarget.value === 0) return []
+  const totalMonths = Math.ceil(chartYears.value * 12)
+  const points = []
+  for (let i = 0; i <= totalMonths; i++) {
+    const value = portfolioValue.value + avgMonthlySavings.value * i
+    const progress = Math.min(100, (value / retirementTarget.value) * 100)
+    points.push({ monthIndex: i, progress })
+  }
+  return points
+})
 </script>
 
 <template>
@@ -208,6 +260,42 @@ const hasNoData = computed(
         </div>
         <p v-if="hasReachedFire" class="text-green-400 text-sm mt-3 text-center font-medium">
           Congratulations — you are financially independent!
+        </p>
+      </div>
+
+      <div v-if="avgMonthlySavings > 0 && !hasReachedFire">
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          FIRE Projection
+        </h3>
+        <div class="grid grid-cols-2 gap-4 mb-4">
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Avg Monthly Savings</p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(avgMonthlySavings) }}</p>
+          </div>
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Estimated FIRE Date</p>
+            <p class="text-2xl font-bold text-white">{{ formattedFireDate }}</p>
+            <p class="text-slate-400 text-sm mt-1">{{ yearsAwayLabel }}</p>
+          </div>
+        </div>
+        <div class="bg-slate-800 rounded-xl p-6">
+          <FireProgressChart
+            :points="projectionPoints"
+            :total-months="Math.ceil(chartYears * 12)"
+            :fire-month-index="monthsToFire !== null ? Math.ceil(monthsToFire) : null"
+            :current-progress="fireProgress"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="avgMonthlySavings <= 0 && !hasReachedFire && last12Months.length > 0"
+        class="bg-slate-800 rounded-xl p-6"
+      >
+        <p class="text-slate-400 text-sm mb-1">Avg Monthly Savings</p>
+        <p class="text-2xl font-bold text-amber-400">{{ formatCurrency(avgMonthlySavings) }}</p>
+        <p class="text-slate-500 text-sm mt-2">
+          Recent spending exceeds income — no FIRE projection available.
         </p>
       </div>
 

--- a/src/components/__tests__/RetirementDashboard.spec.ts
+++ b/src/components/__tests__/RetirementDashboard.spec.ts
@@ -7,7 +7,7 @@ import RetirementDashboard from '../RetirementDashboard.vue'
 describe('RetirementDashboard', () => {
   let ynab: ReturnType<typeof useYnabStore>
 
-  const makeMonth = (monthsAgo: number, income: number, deleted = false) => {
+  const makeMonth = (monthsAgo: number, income: number, deleted = false, activity = -income) => {
     const d = new Date()
     d.setDate(1)
     d.setMonth(d.getMonth() - monthsAgo)
@@ -15,7 +15,7 @@ describe('RetirementDashboard', () => {
       month: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`,
       income,
       budgeted: income,
-      activity: -income,
+      activity,
       to_be_budgeted: 0,
       deleted
     }
@@ -113,5 +113,68 @@ describe('RetirementDashboard', () => {
     const changeBtn = wrapper.findAll('button').find((b) => b.text().includes('Change accounts'))
     await changeBtn!.trigger('click')
     expect(wrapper.emitted('change-accounts')).toBeTruthy()
+  })
+
+  describe('FIRE projection', () => {
+    it('shows avg monthly savings when net savings are positive', () => {
+      // income £2,000, spending £1,500 → net £500/month
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -1_500_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toContain('£500')
+    })
+
+    it('shows estimated FIRE date as a year', () => {
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -1_500_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toMatch(/20\d\d/)
+    })
+
+    it('shows "years away" label', () => {
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -1_500_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toContain('years away')
+    })
+
+    it('shows warning when net savings are zero or negative', () => {
+      // spending equals income → net £0
+      ynab.months = Array.from({ length: 12 }, (_, i) => makeMonth(i + 1, 2_000_000)) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toContain('spending exceeds income')
+    })
+
+    it('shows warning when spending exceeds income', () => {
+      // spending more than income → net -£1,000
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -3_000_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toContain('spending exceeds income')
+    })
+
+    it('hides projection when already at FIRE', () => {
+      // portfolio of £600,000 meets the £600k target at 4%
+      ynab.accounts = [{ id: 'acc1', balance: 600_000_000, closed: false, deleted: false }] as any
+      ynab.selectedAccountIds = ['acc1']
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -1_500_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).not.toContain('FIRE Projection')
+      expect(wrapper.text()).not.toContain('spending exceeds income')
+    })
+
+    it('shows FIRE projection heading when savings are positive', () => {
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -1_000_000)
+      ) as any
+      const wrapper = mount(RetirementDashboard)
+      expect(wrapper.text()).toContain('FIRE Projection')
+    })
   })
 })

--- a/src/components/__tests__/RetirementDashboard.spec.ts
+++ b/src/components/__tests__/RetirementDashboard.spec.ts
@@ -176,5 +176,24 @@ describe('RetirementDashboard', () => {
       const wrapper = mount(RetirementDashboard)
       expect(wrapper.text()).toContain('FIRE Projection')
     })
+
+    it('computes monthly savings from selected categories when set', () => {
+      // avg income £2,000/month; selected categories budget £1,200/month → savings £800
+      ynab.months = Array.from({ length: 12 }, (_, i) =>
+        makeMonth(i + 1, 2_000_000, false, -2_000_000)
+      ) as any
+      ynab.categoryGroups = [
+        {
+          id: 'g1',
+          name: 'Living',
+          categories: [{ id: 'c1', budgeted: 1_200_000 } as any]
+        }
+      ] as any
+      ynab.selectedCategoryIds = ['c1']
+      const wrapper = mount(RetirementDashboard)
+      // savings = £2,000 income - £1,200 selected categories = £800
+      expect(wrapper.text()).toContain('£800')
+      expect(wrapper.text()).toContain('FIRE Projection')
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Adds a **FIRE Projection** section below the progress bar showing avg monthly savings and the estimated FIRE date (month + year, plus "~N years away")
- Adds a pure-SVG projection chart (no external charting library) with an indigo→purple gradient line, shaded fill, year labels, and a vertical marker at the projected FIRE date
- When retirement budget categories are selected, monthly savings is computed as `avgMonthlyIncome − selectedCategoriesMonthly`; falls back to `income + activity` from month summaries when no categories are selected
- Shows an amber warning card when spending ≥ income (projection unavailable); hides the section entirely when FIRE is already reached

## Test plan

- [ ] `npm run test:unit` — 31 tests passing (7 new projection tests + 1 category-savings test)
- [ ] `make check` — format + lint + type-check clean
- [ ] Authorize with YNAB, select a budget, accounts, and categories → verify projection section appears with correct savings, FIRE date, and chart
- [ ] Switch withdrawal rate → verify estimated FIRE date and chart update reactively
- [ ] Set categories with spending > income → verify amber warning replaces projection
- [ ] Reach FIRE (portfolio ≥ target) → verify projection section is hidden and congratulations message shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)