### PR TITLE
feat: skip selection screens when accounts and categories are already saved

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -8,14 +8,14 @@ import RetirementDashboard from '@/components/RetirementDashboard.vue'
 import LockIcon from '@/components/icons/LockIcon.vue'
 
 const ynab = useYnabStore()
-const isAccountsConfirmed = ref(false)
-const isCategoriesConfirmed = ref(false)
+const isAccountsConfirmed = ref(ynab.selectedAccountIds.length > 0)
+const isCategoriesConfirmed = ref(ynab.selectedCategoryIds.length > 0)
 
 watch(
   () => ynab.selectedBudget,
   () => {
-    isAccountsConfirmed.value = false
-    isCategoriesConfirmed.value = false
+    isAccountsConfirmed.value = ynab.selectedAccountIds.length > 0
+    isCategoriesConfirmed.value = ynab.selectedCategoryIds.length > 0
   }
 )
 


### PR DESCRIPTION
## Summary

- Initializes `isAccountsConfirmed` and `isCategoriesConfirmed` from the length of their respective localStorage arrays instead of hardcoding `false`
- Updates the `selectedBudget` watcher to apply the same logic on budget change
- When a user selects a budget and their previous account/category choices are already in localStorage, they land directly on the dashboard

## Test plan

- [ ] Authorize, select a budget, pick accounts, pick categories → reach the dashboard
- [ ] Navigate back to budget list ("Back to budgets") → localStorage is cleared, re-selecting the budget shows the full selection flow again
- [ ] From the dashboard, click "← Change accounts" → returns to account selection as expected
- [ ] From the dashboard, click "← Change categories" → returns to category selection as expected
- [ ] In a fresh session with no localStorage data, the full selection flow is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)