### PR TITLE
feat: display historical FIRE progress in projection chart

### DIFF
--- a/src/components/FireProgressChart.vue
+++ b/src/components/FireProgressChart.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   totalMonths: number
   fireMonthIndex: number | null
   currentProgress: number
+  historyMonths: number
 }>()
 
 const LEFT = 48
@@ -35,26 +36,39 @@ const baseYear = new Date().getFullYear()
 const xAxisLabels = computed(() => {
   const labels: { x: number; label: string }[] = []
   for (let m = 0; m <= props.totalMonths; m += yearStepMonths.value) {
-    labels.push({ x: xFor(m), label: String(baseYear + Math.round(m / 12)) })
+    labels.push({
+      x: xFor(m),
+      label: String(baseYear + Math.round((m - props.historyMonths) / 12))
+    })
   }
   return labels
 })
 
 const gridLines = [0, 25, 50, 75, 100]
 
-const linePoints = computed(() =>
-  props.points.map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`).join(' ')
+const histLinePoints = computed(() =>
+  props.points
+    .filter((p) => p.monthIndex <= props.historyMonths)
+    .map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`)
+    .join(' ')
 )
 
-const areaPoints = computed(() => {
-  if (props.points.length === 0) return ''
-  const last = props.points[props.points.length - 1]
-  const pathPoints = [
-    `${xFor(0)},${BOTTOM}`,
-    ...props.points.map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`),
+const projLinePoints = computed(() =>
+  props.points
+    .filter((p) => p.monthIndex >= props.historyMonths)
+    .map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`)
+    .join(' ')
+)
+
+const projAreaPoints = computed(() => {
+  const pts = props.points.filter((p) => p.monthIndex >= props.historyMonths)
+  if (pts.length === 0) return ''
+  const last = pts[pts.length - 1]
+  return [
+    `${xFor(pts[0].monthIndex)},${BOTTOM}`,
+    ...pts.map(({ monthIndex, progress }) => `${xFor(monthIndex)},${yFor(progress)}`),
     `${xFor(last.monthIndex)},${BOTTOM}`
-  ]
-  return pathPoints.join(' ')
+  ].join(' ')
 })
 </script>
 
@@ -106,19 +120,47 @@ const areaPoints = computed(() => {
     />
     <text :x="RIGHT + 4" :y="yFor(100) + 4" fill="#6366f1" font-size="10">FIRE</text>
 
-    <!-- Filled area under the line -->
-    <polygon v-if="points.length > 0" :points="areaPoints" fill="url(#fire-fill)" />
+    <!-- Filled area under projection -->
+    <polygon v-if="projAreaPoints" :points="projAreaPoints" fill="url(#fire-fill)" />
+
+    <!-- Historical line -->
+    <polyline
+      v-if="histLinePoints"
+      :points="histLinePoints"
+      fill="none"
+      stroke="#475569"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      opacity="0.8"
+    />
 
     <!-- Projection line -->
     <polyline
-      v-if="points.length > 0"
-      :points="linePoints"
+      v-if="projLinePoints"
+      :points="projLinePoints"
       fill="none"
       stroke="url(#fire-line)"
       stroke-width="2.5"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
+
+    <!-- Today marker -->
+    <g v-if="historyMonths > 0">
+      <line
+        :x1="xFor(historyMonths)"
+        :x2="xFor(historyMonths)"
+        :y1="TOP"
+        :y2="BOTTOM"
+        stroke="#64748b"
+        stroke-width="1"
+        stroke-dasharray="3 3"
+      />
+      <text :x="xFor(historyMonths)" y="276" fill="#64748b" font-size="9" text-anchor="middle">
+        Today
+      </text>
+    </g>
 
     <!-- Estimated FIRE date vertical marker -->
     <g v-if="fireMonthIndex !== null && fireMonthIndex <= totalMonths">
@@ -143,7 +185,7 @@ const areaPoints = computed(() => {
 
     <!-- Today's dot -->
     <circle
-      :cx="xFor(0)"
+      :cx="xFor(historyMonths)"
       :cy="yFor(currentProgress)"
       r="4"
       fill="#6366f1"

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -33,6 +33,14 @@ const last12Months = computed(() => {
     .slice(0, 12)
 })
 
+const completedMonths = computed(() => {
+  const now = new Date()
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
+  return ynab.months
+    .filter((m) => m.month < currentMonth && !m.deleted)
+    .sort((a, b) => a.month.localeCompare(b.month))
+})
+
 const avgMonthlyIncome = computed(() => {
   if (last12Months.value.length === 0) return 0
   return last12Months.value.reduce((sum, m) => sum + m.income, 0) / last12Months.value.length / 1000
@@ -111,17 +119,44 @@ const chartYears = computed(() =>
   yearsToFire.value === null ? 40 : Math.min(yearsToFire.value + 2, 40)
 )
 
+const historicalPoints = computed(() => {
+  if (retirementTarget.value === 0 || completedMonths.value.length === 0) return []
+  const months = completedMonths.value
+  const n = months.length
+  const portfolioAtEnd = new Array<number>(n)
+  portfolioAtEnd[n - 1] = portfolioValue.value
+  for (let i = n - 2; i >= 0; i--) {
+    const nextNet = (months[i + 1].income + months[i + 1].activity) / 1000
+    portfolioAtEnd[i] = portfolioAtEnd[i + 1] - nextNet
+  }
+  return portfolioAtEnd.map((pv, i) => ({
+    monthIndex: i,
+    progress: Math.min(100, Math.max(0, (pv / retirementTarget.value) * 100))
+  }))
+})
+
+const historyMonths = computed(() => completedMonths.value.length)
+
 const projectionPoints = computed(() => {
   if (retirementTarget.value === 0) return []
+  const offset = historyMonths.value
   const totalMonths = Math.ceil(chartYears.value * 12)
   const points = []
   for (let i = 0; i <= totalMonths; i++) {
     const value = portfolioValue.value + avgMonthlySavings.value * i
     const progress = Math.min(100, (value / retirementTarget.value) * 100)
-    points.push({ monthIndex: i, progress })
+    points.push({ monthIndex: offset + i, progress })
   }
   return points
 })
+
+const allChartPoints = computed(() => [...historicalPoints.value, ...projectionPoints.value])
+
+const chartTotalMonths = computed(() => historyMonths.value + Math.ceil(chartYears.value * 12))
+
+const chartFireMonthIndex = computed(() =>
+  monthsToFire.value !== null ? historyMonths.value + Math.ceil(monthsToFire.value) : null
+)
 </script>
 
 <template>
@@ -283,10 +318,11 @@ const projectionPoints = computed(() => {
         </div>
         <div class="bg-slate-800 rounded-xl p-6">
           <FireProgressChart
-            :points="projectionPoints"
-            :total-months="Math.ceil(chartYears * 12)"
-            :fire-month-index="monthsToFire !== null ? Math.ceil(monthsToFire) : null"
+            :points="allChartPoints"
+            :total-months="chartTotalMonths"
+            :fire-month-index="chartFireMonthIndex"
             :current-progress="fireProgress"
+            :history-months="historyMonths"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Reconstructs historical portfolio values from YNAB monthly `income + activity` data by working backward from the current balance
- Renders a slate-coloured historical line to the left of a "Today" dashed marker, seamlessly joining the existing indigo/purple projection gradient
- X-axis year labels are anchored on today so past years appear on the left and future years on the right

## Test plan

- [ ] All 31 unit tests pass (`npm run test:unit`)
- [ ] `make check` passes (format + lint + type-check)
- [ ] Historical line visible in the chart to the left of the "Today" marker
- [ ] Projection gradient continues to the right unchanged
- [ ] X-axis year labels are correct (past years left, future years right)
- [ ] Today dot sits at the join between historical and projection segments
- [ ] FIRE estimated-date marker appears correctly on the projection side

🤖 Generated with [Claude Code](https://claude.com/claude-code)