### PR TITLE
feat: debt payoff timeline chart

### DIFF
--- a/src/components/DebtPayoffChart.vue
+++ b/src/components/DebtPayoffChart.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  points: Array<{ monthIndex: number; balance: number }>
+  totalMonths: number
+  payoffMonthIndex: number | null
+  maxBalance: number
+}>()
+
+const LEFT = 48
+const RIGHT = 776
+const TOP = 16
+const BOTTOM = 264
+const PLOT_W = RIGHT - LEFT
+const PLOT_H = BOTTOM - TOP
+
+function xFor(monthIndex: number): number {
+  return LEFT + (monthIndex / props.totalMonths) * PLOT_W
+}
+
+function yFor(balance: number): number {
+  if (props.maxBalance === 0) return BOTTOM
+  return BOTTOM - (balance / props.maxBalance) * PLOT_H
+}
+
+function fmtBalance(v: number): string {
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000) return `${Math.round(v / 1_000)}k`
+  return Math.round(v).toString()
+}
+
+const yearStepMonths = computed(() => {
+  const years = props.totalMonths / 12
+  if (years <= 10) return 12
+  if (years <= 20) return 24
+  return 60
+})
+
+const baseYear = new Date().getFullYear()
+
+const xAxisLabels = computed(() => {
+  const labels: { x: number; label: string }[] = []
+  for (let m = 0; m <= props.totalMonths; m += yearStepMonths.value) {
+    labels.push({ x: xFor(m), label: String(baseYear + Math.round(m / 12)) })
+  }
+  return labels
+})
+
+const gridLevels = [0, 0.25, 0.5, 0.75, 1]
+
+const linePoints = computed(() =>
+  props.points.map(({ monthIndex, balance }) => `${xFor(monthIndex)},${yFor(balance)}`).join(' ')
+)
+
+const areaPoints = computed(() => {
+  if (props.points.length === 0) return ''
+  const last = props.points[props.points.length - 1]
+  const pathPoints = [
+    `${xFor(0)},${BOTTOM}`,
+    ...props.points.map(({ monthIndex, balance }) => `${xFor(monthIndex)},${yFor(balance)}`),
+    `${xFor(last.monthIndex)},${BOTTOM}`
+  ]
+  return pathPoints.join(' ')
+})
+</script>
+
+<template>
+  <svg
+    viewBox="0 0 800 300"
+    class="w-full h-auto"
+    role="img"
+    aria-label="Debt payoff projection chart"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <linearGradient id="debt-fill" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.35" />
+        <stop offset="100%" stop-color="#fbbf24" stop-opacity="0.05" />
+      </linearGradient>
+      <linearGradient id="debt-line" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="#f59e0b" />
+        <stop offset="100%" stop-color="#fbbf24" />
+      </linearGradient>
+    </defs>
+
+    <!-- Y-axis gridlines -->
+    <g v-for="level in gridLevels" :key="level">
+      <line
+        :x1="LEFT"
+        :x2="RIGHT"
+        :y1="yFor(maxBalance * level)"
+        :y2="yFor(maxBalance * level)"
+        stroke="#334155"
+        stroke-width="1"
+        stroke-dasharray="4 4"
+      />
+      <text
+        :x="LEFT - 6"
+        :y="yFor(maxBalance * level) + 4"
+        fill="#64748b"
+        font-size="10"
+        text-anchor="end"
+      >
+        {{ fmtBalance(maxBalance * (1 - level)) }}
+      </text>
+    </g>
+
+    <!-- Debt-free baseline (more prominent) -->
+    <line
+      :x1="LEFT"
+      :x2="RIGHT"
+      :y1="BOTTOM"
+      :y2="BOTTOM"
+      stroke="#f59e0b"
+      stroke-width="1.5"
+      stroke-dasharray="6 4"
+      opacity="0.7"
+    />
+    <text :x="RIGHT + 4" :y="BOTTOM + 4" fill="#f59e0b" font-size="10">$0</text>
+
+    <!-- Filled area under the line -->
+    <polygon v-if="points.length > 0" :points="areaPoints" fill="url(#debt-fill)" />
+
+    <!-- Projection line -->
+    <polyline
+      v-if="points.length > 0"
+      :points="linePoints"
+      fill="none"
+      stroke="url(#debt-line)"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <!-- Payoff date vertical marker -->
+    <g v-if="payoffMonthIndex !== null && payoffMonthIndex <= totalMonths">
+      <line
+        :x1="xFor(payoffMonthIndex)"
+        :x2="xFor(payoffMonthIndex)"
+        :y1="TOP"
+        :y2="BOTTOM"
+        stroke="#f59e0b"
+        stroke-width="1.5"
+        stroke-dasharray="4 4"
+      />
+      <circle
+        :cx="xFor(payoffMonthIndex)"
+        :cy="BOTTOM"
+        r="5"
+        fill="#f59e0b"
+        stroke="#1e293b"
+        stroke-width="2"
+      />
+      <text :x="xFor(payoffMonthIndex) + 8" :y="BOTTOM - 8" fill="#f59e0b" font-size="10">
+        Debt-Free
+      </text>
+    </g>
+
+    <!-- Today's dot -->
+    <circle
+      :cx="xFor(0)"
+      :cy="yFor(maxBalance)"
+      r="4"
+      fill="#f59e0b"
+      stroke="#1e293b"
+      stroke-width="2"
+    />
+
+    <!-- X-axis year labels -->
+    <text
+      v-for="label in xAxisLabels"
+      :key="label.label"
+      :x="label.x"
+      y="288"
+      fill="#64748b"
+      font-size="10"
+      text-anchor="middle"
+    >
+      {{ label.label }}
+    </text>
+  </svg>
+</template>

--- a/src/components/RetirementDashboard.vue
+++ b/src/components/RetirementDashboard.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useYnabStore } from '@/stores/ynab'
 import { useFormatCurrency } from '@/composables/useFormatCurrency'
 import FireProgressChart from '@/components/FireProgressChart.vue'
+import DebtPayoffChart from '@/components/DebtPayoffChart.vue'
 
 const emit = defineEmits<{ 'change-accounts': []; 'change-categories': [] }>()
 
@@ -109,6 +110,100 @@ const yearsAwayLabel = computed(() => {
 
 const chartYears = computed(() =>
   yearsToFire.value === null ? 40 : Math.min(yearsToFire.value + 2, 40)
+)
+
+function getMostRecentValue(map: Record<string, number> | null | undefined): number {
+  if (!map) return 0
+  const entries = Object.entries(map).sort((a, b) => b[0].localeCompare(a[0]))
+  return entries.length > 0 ? entries[0][1] : 0
+}
+
+const DEBT_ACCOUNT_TYPES = [
+  'creditCard',
+  'lineOfCredit',
+  'mortgage',
+  'autoLoan',
+  'studentLoan',
+  'personalLoan',
+  'medicalDebt',
+  'otherDebt'
+]
+
+const debtAccounts = computed(() =>
+  ynab.accounts.filter(
+    (a) => !a.closed && !a.deleted && a.balance < 0 && DEBT_ACCOUNT_TYPES.includes(a.type)
+  )
+)
+
+const totalDebt = computed(() => debtAccounts.value.reduce((sum, a) => sum - a.balance, 0) / 1000)
+
+const totalMonthlyDebtPayment = computed(
+  () =>
+    debtAccounts.value.reduce((sum, a) => sum + getMostRecentValue(a.debt_minimum_payments), 0) /
+    1000
+)
+
+const hasDebtPaymentData = computed(() => totalMonthlyDebtPayment.value > 0)
+
+const debtProjectionPoints = computed(() => {
+  if (debtAccounts.value.length === 0 || !hasDebtPaymentData.value) return []
+
+  const debts = debtAccounts.value.map((a) => ({
+    balance: -a.balance / 1000,
+    monthlyRate: getMostRecentValue(a.debt_interest_rates) / 1000 / 100 / 12,
+    monthlyPayment: getMostRecentValue(a.debt_minimum_payments) / 1000
+  }))
+
+  const points: { monthIndex: number; balance: number }[] = [
+    { monthIndex: 0, balance: totalDebt.value }
+  ]
+  const MAX_MONTHS = 600
+
+  for (let i = 1; i <= MAX_MONTHS; i++) {
+    for (const debt of debts) {
+      if (debt.balance > 0) {
+        debt.balance = Math.max(0, debt.balance * (1 + debt.monthlyRate) - debt.monthlyPayment)
+      }
+    }
+    const total = debts.reduce((sum, d) => sum + d.balance, 0)
+    points.push({ monthIndex: i, balance: total })
+    if (total <= 0.01) break
+  }
+
+  return points
+})
+
+const monthsToPayoff = computed(() => {
+  if (debtProjectionPoints.value.length < 2) return null
+  const last = debtProjectionPoints.value[debtProjectionPoints.value.length - 1]
+  return last.balance <= 0.01 ? last.monthIndex : null
+})
+
+const estimatedPayoffDate = computed(() => {
+  if (monthsToPayoff.value === null) return null
+  const d = new Date()
+  d.setDate(1)
+  d.setMonth(d.getMonth() + monthsToPayoff.value)
+  return d
+})
+
+const formattedPayoffDate = computed(() => {
+  if (!estimatedPayoffDate.value) return '—'
+  return estimatedPayoffDate.value.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+})
+
+const yearsToPayoff = computed(() =>
+  monthsToPayoff.value === null ? null : monthsToPayoff.value / 12
+)
+
+const yearsToPayoffLabel = computed(() => {
+  if (yearsToPayoff.value === null) return ''
+  const y = Math.ceil(yearsToPayoff.value)
+  return `~${y} ${y === 1 ? 'year' : 'years'} away`
+})
+
+const debtChartYears = computed(() =>
+  yearsToPayoff.value === null ? 10 : Math.min(yearsToPayoff.value + 1, 50)
 )
 
 const projectionPoints = computed(() => {
@@ -300,6 +395,52 @@ const projectionPoints = computed(() => {
         <p class="text-slate-500 text-sm mt-2">
           Recent spending exceeds income — no FIRE projection available.
         </p>
+      </div>
+
+      <div v-if="debtAccounts.length > 0">
+        <h3 class="text-slate-400 text-xs font-semibold uppercase tracking-wider mb-3">
+          Debt Payoff
+        </h3>
+
+        <div class="grid grid-cols-2 gap-4 mb-4">
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">
+              Total Debt ({{ debtAccounts.length }}
+              {{ debtAccounts.length === 1 ? 'account' : 'accounts' }})
+            </p>
+            <p class="text-2xl font-bold text-white">{{ formatCurrency(totalDebt) }}</p>
+          </div>
+          <div class="bg-slate-800 rounded-xl p-6">
+            <p class="text-slate-400 text-sm mb-1">Monthly Payments</p>
+            <p class="text-2xl font-bold text-white">
+              {{ hasDebtPaymentData ? formatCurrency(totalMonthlyDebtPayment) : '—' }}
+            </p>
+          </div>
+        </div>
+
+        <template v-if="hasDebtPaymentData">
+          <div class="grid grid-cols-2 gap-4 mb-4">
+            <div class="bg-slate-800 rounded-xl p-6">
+              <p class="text-slate-400 text-sm mb-1">Estimated Payoff</p>
+              <p class="text-2xl font-bold text-white">{{ formattedPayoffDate }}</p>
+              <p class="text-slate-400 text-sm mt-1">{{ yearsToPayoffLabel }}</p>
+            </div>
+          </div>
+          <div class="bg-slate-800 rounded-xl p-6">
+            <DebtPayoffChart
+              :points="debtProjectionPoints"
+              :total-months="Math.ceil(debtChartYears * 12)"
+              :payoff-month-index="monthsToPayoff"
+              :max-balance="totalDebt"
+            />
+          </div>
+        </template>
+
+        <div v-else class="bg-slate-800 rounded-xl p-6">
+          <p class="text-slate-400 text-sm">
+            Add minimum payment amounts to your debt accounts in YNAB to see a payoff projection.
+          </p>
+        </div>
       </div>
 
       <p class="text-slate-500 text-xs text-center">


### PR DESCRIPTION
## Summary

- Adds a **Debt Payoff** section to the FIRE Dashboard, below the FIRE Projection chart
- New `DebtPayoffChart.vue` SVG chart (amber color scheme, mirrors `FireProgressChart` architecture) showing total debt balance declining to zero over time
- Includes all non-closed debt-type accounts (credit card, mortgage, auto/student/personal loans, etc.) regardless of portfolio selection
- Month-by-month simulation respects per-account interest rates (`debt_interest_rates`) and minimum payments (`debt_minimum_payments`) from YNAB
- Shows total debt, monthly payments, estimated payoff date, and years away
- Gracefully handles missing payment data with a prompt to configure minimum payments in YNAB
- If no debt accounts exist, the section is hidden entirely

## Test plan

- [ ] `make check` passes (format + lint + type-check)
- [ ] `npm run test:unit` — all 31 existing tests pass
- [ ] Open dashboard with a budget that has debt accounts → Debt Payoff section appears with chart and payoff date
- [ ] Open dashboard with no debt accounts → section is hidden
- [ ] Open dashboard with debt accounts but no minimum payments set → shows "Add minimum payment" message
- [ ] Y-axis shows abbreviated balances (e.g. `25k`, `100k`); X-axis shows year labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)